### PR TITLE
Add deep linking, key up and down support

### DIFF
--- a/docs/RokulRunnings.md
+++ b/docs/RokulRunnings.md
@@ -39,11 +39,13 @@ const rr = new RokulRunnings(/*Roku IP Address =*/'0.0.0.0',
 
 This function launches the specified channel.
 
-| Parameter   | Type   | Description                                                                                                                                       |
-| ----------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| channelCode | string | ID of the channel to be launched. Released Roku channels have a specific `id`, which is a number. Sideloaded channels have the `id` of `'dev'`.   |
-| retries     | number | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is 3.                         |
-| params      | object | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value. |
+| Parameter   | Type   | Description                                                                                                                                                                                    |
+| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| channelCode | string | ID of the channel to be launched. Released Roku channels have a specific `id`, which is a number. Sideloaded channels have the `id` of `'dev'`.                                                |
+| contentId   | string | _Optional_: The ID of the [content](https://developer.roku.com/en-ca/docs/developer-program/discovery/implementing-deep-linking.md#understanding-deep-linking-parameters) to be played         |
+| mediaType   | string | _Optional_: The [mediaType](https://developer.roku.com/en-ca/docs/developer-program/discovery/implementing-deep-linking.md#understanding-deep-linking-parameters) of the content to be played. |
+| retries     | number | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is 3.                                                                      |
+| params      | object | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.                                              |
 
 ### Return
 
@@ -53,6 +55,28 @@ This function returns the response status from the network call.
 
 ```
 const response = await rr.launchTheChannel({channelCode: 'dev', retries: 1});
+```
+
+## deepLinkIntoChannel()
+
+This function deep links into the specified channel
+
+| Parameter   | Type   | Description                                                                                                                                                                        |
+| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| channelCode | string | ID of the channel to be launched. Released Roku channels have a specific `id`, which is a number. Sideloaded channels have the `id` of `'dev'`.                                    |
+| contentId   | string | The ID of the [content](https://developer.roku.com/en-ca/docs/developer-program/discovery/implementing-deep-linking.md#understanding-deep-linking-parameters) to be played         |
+| mediaType   | string | The [mediaType](https://developer.roku.com/en-ca/docs/developer-program/discovery/implementing-deep-linking.md#understanding-deep-linking-parameters) of the content to be played. |
+| retries     | number | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is 3.                                                          |
+| params      | object | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.                                  |
+
+### Return
+
+This function returns the response status from the network call.
+
+### Example
+
+```
+const response = await rr.deepLinkIntoChannel({channelCode: 'dev', contentId: 'myMovieId', mediaType: 'movie'});
 ```
 
 ## getApps()
@@ -141,16 +165,16 @@ const data = elementData.text('textOnElement');
 const isElementOnScreen = await rr.verifyIsElementOnScreen({data});
 ```
 
-## pressBtn()
+## pressBtn() / pressBtnDown() / pressBtnUp/
 
-This function simulates the pressing of a specific key. It is highly suggested that you import the `Buttons` enum to know the possible button strings.
+This function simulates the press and release, press down, or release (press up) of a specific key. It is highly suggested that you import the `Buttons` enum to know the possible button strings.
 
-| Parameter     | Type   | Description                                                                                                                                            |
-| ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| keyPress      | string | The key to be pressed. This can be any of the values from the `buttons` enum, or an alphanumeric key (`LIT_{key}`)                                     |
-| delayInMillis | number | _Optional_: The delay before sending the key press, in milliseconds. The default value is RokulRunning's `pressDelayInMillis` value.                   |
-| retries       | number | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is RokulRunning's `retries` value. |
-| params        | object | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.      |
+| Parameter                  | Type   | Description                                                                                                                                            |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| keyPress / keyDown / keyUp | string | The key to be sent. This can be any of the values from the `buttons` enum, or an alphanumeric key (`LIT_{key}`)                                        |
+| delayInMillis              | number | _Optional_: The delay before sending the key press, in milliseconds. The default value is RokulRunning's `pressDelayInMillis` value.                   |
+| retries                    | number | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is RokulRunning's `retries` value. |
+| params                     | object | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.      |
 
 ### Return
 
@@ -159,7 +183,9 @@ This function returns the response status from the network call.
 ### Examples
 
 ```
-const response = await rr.pressBtn({keyPress: Buttons.up});
+const pressResponse = await rr.pressBtn({keyPress: Buttons.right});
+const downResponse = await rr.pressBtnDown({keyDown: Buttons.select});
+const upResponse = await rr.pressBtnUp({keyUp: Buttons.left})
 ```
 
 ## sendWord()
@@ -202,14 +228,15 @@ const response = await rr.sendWord({word: 'Roku'});
 
 ## sendButtonSequence()
 
-This function sends an array of key presses to the Roku.
+This function sends an array of keys, all of the same keyType (up, down, or press) to the Roku.
 
-| Parameter     | Type          | Description                                                                                                                                            |
-| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| sequence      | buttons array | The sequence of key presses to be sent.                                                                                                                |
-| delayInMillis | number        | _Optional_: The delay before sending the key press, in milliseconds. The default value is RokulRunning's `pressDelayInMillis` value.                   |
-| retries       | number        | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is RokulRunning's `retries` value. |
-| params        | object        | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.      |
+| Parameter     | Type                           | Description                                                                                                                                            |
+| ------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| sequence      | an array of Buttons or strings | The sequence of keys to be sent.                                                                                                                       |
+| delayInMillis | number                         | _Optional_: The delay before sending the key press, in milliseconds. The default value is RokulRunning's `pressDelayInMillis` value.                   |
+| retries       | number                         | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is RokulRunning's `retries` value. |
+| params        | object                         | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.      |
+| keyType       | 'up', 'down', or 'press'       | _Optional_: The key type to be sent, associated with all keys in the sequence. Default value is `'press'`                                              |
 
 ### Return
 
@@ -235,6 +262,49 @@ This function returns an array of objects, with the `Button` as the key and the 
 const buttonSequence = [ buttons.up, buttons.up, buttons.select ]
 
 const response = await rr.sendButtonSequence({sequence: buttonSequence});
+
+const upResponse = await rr.sendButtonSequence({sequence: buttonSequence, keyType: 'up'})
+```
+
+## sendMixedButtonSequence
+
+This function sends an array of keys, with mixed keyTypes (up, down, or press) to the Roku.
+
+| Parameter      | Type                | Description                                                                                                                                                                            |
+| -------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| customSequence | an array of objects | The sequence of keys and keyTypes to be sent. Each object in the array should take the format of the keyType (up, down, or press) as the object key, and the key to send as the value. |
+| delayInMillis  | number              | _Optional_: The delay before sending the key press, in milliseconds. The default value is RokulRunning's `pressDelayInMillis` value.                                                   |
+| retries        | number              | _Optional_: The number of times the axios call will be retried if a 500 error status is received. The default value is RokulRunning's `retries` value.                                 |
+| params         | object              | _Optional_: Parameters to be passed into the POST request, appended as query parameters on the end of the request URL. There is no default value.                                      |
+
+### Return
+
+This function returns an array of objects, with the keyType and key as the object key (as `"keyType:key"`), and the response statuses as the value.
+
+```
+[
+  {
+    "up:select": 200
+  },
+  {
+    "down:right": 200
+  },
+  {
+    "press:left": 200
+  }
+]
+```
+
+### Example
+
+```
+const customSequence = [
+  { up: Buttons.select },
+  { down: Buttons.right },
+  { press: Buttons.left }
+]
+
+const response = await rr.sendMixedButtonSequence({customSequence});
 ```
 
 ## getElement(), getElements()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willowtreeapps/rokul-runnings",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Library to send automated commands to a Roku",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/modules/Driver.ts
+++ b/src/modules/Driver.ts
@@ -191,21 +191,6 @@ export class Driver {
     return response;
   }
 
-  /** Simulates the press and release of the specified key. */
-  async sendKeyPress({ keyPress, retries, params }: { keyPress: string; retries: number; params: Params }) {
-    return this.sendKey({ keyType: 'press', key: keyPress, retries, params });
-  }
-
-  /** Simulates the press down of the specified key. */
-  async sendKeyDown({ keyDown, retries, params }: { keyDown: string; retries: number; params: Params }) {
-    return this.sendKey({ keyType: 'down', key: keyDown, retries, params });
-  }
-
-  /** Simulates the press up of the specified key. */
-  async sendKeyUp({ keyUp, retries, params }: { keyUp: string; retries: number; params: Params }) {
-    return this.sendKey({ keyType: 'up', key: keyUp, retries, params });
-  }
-
   /** Sends a sequence of keys to be input by the device */
   async sendSequence({
     sequence,
@@ -213,13 +198,12 @@ export class Driver {
     retries,
     params,
   }: {
-    sequence: { up?: string | Buttons; down?: string | Buttons; press?: string | Buttons }[];
+    sequence: ({ up: string | Buttons } | { down: string | Buttons } | { press: string | Buttons })[];
     delayInMillis: number;
     retries: number;
     params: Params;
   }) {
-    // eslint-disable-next-line prefer-const
-    let responseArray: { [key: string]: number }[] = [];
+    const responseArray: { [key: string]: number }[] = [];
     for (let i = 0; i < sequence.length; i++) {
       const keyObject = sequence[i];
       if (Object.keys(keyObject).length === 1) {

--- a/src/modules/RokulRunnings.ts
+++ b/src/modules/RokulRunnings.ts
@@ -240,8 +240,16 @@ export class RokulRunnings {
   }) {
     const newSequence: ({ up: string | Buttons } | { down: string | Buttons } | { press: string | Buttons })[] = [];
     sequence.forEach(button => {
-      if (keyType === 'up' || keyType === 'down' || keyType === 'press') {
-        newSequence.push({ [keyType]: button });
+      switch (keyType) {
+        case 'down':
+          newSequence.push({ down: button });
+          break;
+        case 'press':
+          newSequence.push({ press: button });
+          break;
+        case 'up':
+          newSequence.push({ up: button });
+          break;
       }
     });
     const response = await this.driver.sendSequence({ sequence: newSequence, delayInMillis, params, retries });

--- a/src/modules/RokulRunnings.ts
+++ b/src/modules/RokulRunnings.ts
@@ -232,7 +232,7 @@ export class RokulRunnings {
     params,
     keyType = 'press',
   }: {
-    sequence: Buttons[] | string[];
+    sequence: (Buttons | string)[];
     delayInMillis?: number;
     retries?: number;
     params?: Params;

--- a/src/modules/RokulRunnings.ts
+++ b/src/modules/RokulRunnings.ts
@@ -164,7 +164,7 @@ export class RokulRunnings {
     retries?: number;
     params?: Params;
   }) {
-    const response = await this.driver.sendKeyPress({ keyPress, retries, params });
+    const response = await this.driver.sendKey({ keyType: 'press', key: keyPress, retries, params });
     await sleep(delayInMillis);
     return response;
   }
@@ -181,7 +181,7 @@ export class RokulRunnings {
     retries?: number;
     params?: Params;
   }) {
-    const response = await this.driver.sendKeyDown({ keyDown, retries, params });
+    const response = await this.driver.sendKey({ keyType: 'down', key: keyDown, retries, params });
     await sleep(delayInMillis);
     return response;
   }
@@ -198,7 +198,7 @@ export class RokulRunnings {
     retries?: number;
     params?: Params;
   }) {
-    const response = await this.driver.sendKeyUp({ keyUp, retries, params });
+    const response = await this.driver.sendKey({ keyType: 'up', key: keyUp, retries, params });
     await sleep(delayInMillis);
     return response;
   }
@@ -238,11 +238,9 @@ export class RokulRunnings {
     params?: Params;
     keyType?: 'up' | 'down' | 'press';
   }) {
-    const newSequence: { up?: string | Buttons; down?: string | Buttons; press?: string | Buttons }[] = [];
+    const newSequence: ({ up: string | Buttons } | { down: string | Buttons } | { press: string | Buttons })[] = [];
     sequence.forEach(button => {
-      if (!newSequence) {
-        newSequence[0] = { [keyType]: button };
-      } else {
+      if (keyType === 'up' || keyType === 'down' || keyType === 'press') {
         newSequence.push({ [keyType]: button });
       }
     });
@@ -263,7 +261,7 @@ export class RokulRunnings {
     retries = this.retries,
     params,
   }: {
-    customSequence: [{ up?: string; down?: string; press?: string }];
+    customSequence: ({ up: string } | { down: string } | { press: string })[];
     delayInMillis?: number;
     retries?: number;
     params?: Params;

--- a/test/rokul-runnings-unit-tests.ts
+++ b/test/rokul-runnings-unit-tests.ts
@@ -63,10 +63,20 @@ describe('Rokul Runnings Unit tests', function() {
 
   it('Should Launch the Channel', async function() {
     nock(baseURL)
-      .post(`/launch/dev`)
+      .post(/\/launch\/dev/)
       .reply(200);
 
     const response = await rr.launchTheChannel({ channelCode: 'dev' });
+
+    expect(response).to.eql(200);
+  });
+
+  it('Should Deep Link Into the Channel', async function() {
+    nock(baseURL)
+      .post(/\/input/)
+      .reply(200);
+
+    const response = await rr.deepLinkIntoChannel({ channelCode: 'dev', contentId: 'content', mediaType: 'video' });
 
     expect(response).to.eql(200);
   });
@@ -123,6 +133,22 @@ describe('Rokul Runnings Unit tests', function() {
     expect(await rr.pressBtn({ keyPress: Buttons.up, delayInMillis: 100 })).to.eql(200);
   });
 
+  it('Should Verify Button is Pressed Down', async function() {
+    nock(baseURL)
+      .post(`/keydown/up`)
+      .reply(200);
+
+    expect(await rr.pressBtnDown({ keyDown: Buttons.up, delayInMillis: 100 })).to.eql(200);
+  });
+
+  it('Should Verify Button is Pressed Up', async function() {
+    nock(baseURL)
+      .post(`/keyup/up`)
+      .reply(200);
+
+    expect(await rr.pressBtnUp({ keyUp: Buttons.up, delayInMillis: 100 })).to.eql(200);
+  });
+
   it('Should Verify Word is Pressed', async function() {
     const word = 'hello';
 
@@ -155,6 +181,19 @@ describe('Rokul Runnings Unit tests', function() {
     }
 
     const response = await rr.sendButtonSequence({ sequence: buttonSequence, delayInMillis: 100 });
+
+    expect(response).to.eql(expectedResponse);
+  });
+
+  it('Should Verify Mixed Button Sequence is Pressed', async function() {
+    nock(baseURL)
+      .post(/key.*\/.*/)
+      .reply(200)
+      .persist();
+
+    const customSequence = [{ up: Buttons.up }, { down: Buttons.down }, { press: Buttons.select }];
+    const expectedResponse = [{ 'up:up': 200 }, { 'down:down': 200 }, { 'press:select': 200 }];
+    const response = await rr.sendMixedButtonSequence({ customSequence, delayInMillis: 100 });
 
     expect(response).to.eql(expectedResponse);
   });

--- a/test/rokul-runnings-unit-tests.ts
+++ b/test/rokul-runnings-unit-tests.ts
@@ -127,7 +127,7 @@ describe('Rokul Runnings Unit tests', function() {
 
   it('Should Verify Button is Pressed', async function() {
     nock(baseURL)
-      .post(`/keypress/up`)
+      .post(/keypress\/.*/)
       .reply(200);
 
     expect(await rr.pressBtn({ keyPress: Buttons.up, delayInMillis: 100 })).to.eql(200);
@@ -135,7 +135,7 @@ describe('Rokul Runnings Unit tests', function() {
 
   it('Should Verify Button is Pressed Down', async function() {
     nock(baseURL)
-      .post(`/keydown/up`)
+      .post(/keydown\/.*/)
       .reply(200);
 
     expect(await rr.pressBtnDown({ keyDown: Buttons.up, delayInMillis: 100 })).to.eql(200);
@@ -143,7 +143,7 @@ describe('Rokul Runnings Unit tests', function() {
 
   it('Should Verify Button is Pressed Up', async function() {
     nock(baseURL)
-      .post(`/keyup/up`)
+      .post(/keyup\/.*/)
       .reply(200);
 
     expect(await rr.pressBtnUp({ keyUp: Buttons.up, delayInMillis: 100 })).to.eql(200);


### PR DESCRIPTION
Fixes: #37 
Fixes: #32 
Add key up
Add key down
Add deep linking
Modify channel launch to support deep linking
(Also updated docs and added unit tests)
(Also bumped the version to `0.3.0`)

- Idea is that the user can now send a keyPress, keyUp, or keyDown individually
- The assumption is that sending a word is always a keyPress
- `sendButtonSequence` now supports specifying that _all_ keys in the sequence are the same type (all down, up, or press). Logic in this function creates the required sequence array that contains the object.
- sendMixedButtonSequence allows users to specify specific keyUp/Down/Press combinations within a sequence... such as `[ {up: 'back'}, {down: 'up'}, {press: 'select'} ]`
- Logic in `sendSequence` on `Driver` parses the sequence to figure out which key to send